### PR TITLE
受け入れテスト実装

### DIFF
--- a/vending-machine-acceptance-test/src/test/java/org/contourgara/AcceptanceTest.java
+++ b/vending-machine-acceptance-test/src/test/java/org/contourgara/AcceptanceTest.java
@@ -11,6 +11,7 @@ import ch.qos.logback.core.Appender;
 import org.contourgara.util.StandardInputStream;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
@@ -37,22 +38,128 @@ class AcceptanceTest {
      System.setIn(null);
    }
 
+   @BeforeEach
+   void setUp() {
+     MockitoAnnotations.openMocks(this);
+     Logger logger = (Logger) LoggerFactory.getLogger(VendingMachine.class);
+     logger.addAppender(appender);
+   }
+
+   @Test
+   void 自販機を起動し終了する() {
+     // set up
+     standardInputStream.inputln("3");
+
+     // execute
+     Main.main(null);
+
+     // assert
+     verify(appender, times(11)).doAppend(argumentCaptor.capture());
+     assertThat(argumentCaptor.getAllValues().stream().map(LoggingEvent::getLevel).map(Level::toString)).containsOnly("INFO");
+     assertThat(argumentCaptor.getAllValues().get(0).getMessage()).isEqualTo("自動販売機へようこそ！");
+     assertThat(argumentCaptor.getAllValues().get(5).getMessage()).isEqualTo("現在の投入金額: 0円");
+     assertThat(argumentCaptor.getAllValues().get(10).getMessage()).isEqualTo("--- 自動販売機を終了します。ありがとうございました！ ---");
+   }
+
+   @Test
+   void コインを1度投入しコーラを買うことができ投入金額が0になる() {
+     // set up
+     standardInputStream.inputln("1");
+     standardInputStream.inputln("2");
+     standardInputStream.inputln("1");
+     standardInputStream.inputln("3");
+
+     // execute
+     Main.main(null);
+
+     // assert
+     verify(appender, times(37)).doAppend(argumentCaptor.capture());
+     assertThat(argumentCaptor.getAllValues().stream().map(LoggingEvent::getLevel).map(Level::toString)).containsOnly("INFO");
+     assertThat(argumentCaptor.getAllValues().get(10).getMessage()).isEqualTo("現在の投入金額: 100円");
+     assertThat(argumentCaptor.getAllValues().get(25).getMessage()).isEqualTo("--- コーラを購入しました。 ---");
+     assertThat(argumentCaptor.getAllValues().get(26).getMessage()).isEqualTo("現在の投入金額: 0円");
+   }
+
   @Test
-  void 文字列がログに出力される() {
-    // setup
-    MockitoAnnotations.openMocks(this);
-    Logger logger = (Logger) LoggerFactory.getLogger(VendingMachine.class);
-    logger.addAppender(appender);
+  void コインを1度投入しウーロン茶を買うことができ投入金額が0になる() {
+    // set up
+    standardInputStream.inputln("1");
+    standardInputStream.inputln("2");
+    standardInputStream.inputln("2");
+    standardInputStream.inputln("3");
 
     // execute
-    standardInputStream.inputln("3");
-    Main.main(new String[] {});
+    Main.main(null);
 
     // assert
-    verify(appender, times(11)).doAppend(argumentCaptor.capture());
+    verify(appender, times(37)).doAppend(argumentCaptor.capture());
     assertThat(argumentCaptor.getAllValues().stream().map(LoggingEvent::getLevel).map(Level::toString)).containsOnly("INFO");
-    assertThat(argumentCaptor.getAllValues().get(0).getMessage()).isEqualTo("自動販売機へようこそ！");
-    assertThat(argumentCaptor.getAllValues().get(10).getMessage()).isEqualTo("--- 自動販売機を終了します。ありがとうございました！ ---");
-    assertThat(argumentCaptor.getAllValues().stream().map(LoggingEvent::getMessage)).contains("商品一覧:");
+    assertThat(argumentCaptor.getAllValues().get(10).getMessage()).isEqualTo("現在の投入金額: 100円");
+    assertThat(argumentCaptor.getAllValues().get(25).getMessage()).isEqualTo("--- ウーロン茶を購入しました。 ---");
+    assertThat(argumentCaptor.getAllValues().get(26).getMessage()).isEqualTo("現在の投入金額: 0円");
+  }
+
+  @Test
+  void コインを1度投入しレッドブルを買うことができず投入金額が100になる() {
+    // set up
+    standardInputStream.inputln("1");
+    standardInputStream.inputln("2");
+    standardInputStream.inputln("3");
+    standardInputStream.inputln("3");
+
+    // execute
+    Main.main(null);
+
+    // assert
+    verify(appender, times(36)).doAppend(argumentCaptor.capture());
+    assertThat(argumentCaptor.getAllValues().stream().map(LoggingEvent::getLevel).map(Level::toString)).containsOnly("INFO");
+    assertThat(argumentCaptor.getAllValues().get(10).getMessage()).isEqualTo("現在の投入金額: 100円");
+    assertThat(argumentCaptor.getAllValues().get(20).getMessage()).isEqualTo("--- 購入する商品を選択してください。 ---");
+    assertThat(argumentCaptor.getAllValues().get(25).getMessage()).isEqualTo("--- 投入金額が不足しています ---");
+    assertThat(argumentCaptor.getAllValues().get(30).getMessage()).isEqualTo("現在の投入金額: 100円");
+  }
+
+  @Test
+  void コインを2度投入しコーラを買うことができ投入金額が100になる() {
+    // set up
+    standardInputStream.inputln("1");
+    standardInputStream.inputln("1");
+    standardInputStream.inputln("2");
+    standardInputStream.inputln("1");
+    standardInputStream.inputln("3");
+
+    // execute
+    Main.main(null);
+
+    // assert
+    verify(appender, times(47)).doAppend(argumentCaptor.capture());
+    assertThat(argumentCaptor.getAllValues().stream().map(LoggingEvent::getLevel).map(Level::toString)).containsOnly("INFO");
+    assertThat(argumentCaptor.getAllValues().get(10).getMessage()).isEqualTo("現在の投入金額: 100円");
+    assertThat(argumentCaptor.getAllValues().get(25).getMessage()).isEqualTo("現在の投入金額: 200円");
+    assertThat(argumentCaptor.getAllValues().get(30).getMessage()).isEqualTo("--- 購入する商品を選択してください。 ---");
+    assertThat(argumentCaptor.getAllValues().get(35).getMessage()).isEqualTo("--- コーラを購入しました。 ---");
+    assertThat(argumentCaptor.getAllValues().get(36).getMessage()).isEqualTo("現在の投入金額: 100円");
+  }
+
+  @Test
+  void コインを2度投入しレッドブルを買うことができ投入金額が0になる() {
+    // set up
+    standardInputStream.inputln("1");
+    standardInputStream.inputln("1");
+    standardInputStream.inputln("2");
+    standardInputStream.inputln("3");
+    standardInputStream.inputln("3");
+
+    // execute
+    Main.main(null);
+
+    // assert
+    verify(appender, times(47)).doAppend(argumentCaptor.capture());
+    assertThat(argumentCaptor.getAllValues().stream().map(LoggingEvent::getLevel).map(Level::toString)).containsOnly("INFO");
+    assertThat(argumentCaptor.getAllValues().get(10).getMessage()).isEqualTo("現在の投入金額: 100円");
+    assertThat(argumentCaptor.getAllValues().get(25).getMessage()).isEqualTo("現在の投入金額: 200円");
+    assertThat(argumentCaptor.getAllValues().get(30).getMessage()).isEqualTo("--- 購入する商品を選択してください。 ---");
+    assertThat(argumentCaptor.getAllValues().get(35).getMessage()).isEqualTo("--- レッドブルを購入しました。 ---");
+    assertThat(argumentCaptor.getAllValues().get(36).getMessage()).isEqualTo("現在の投入金額: 0円");
   }
 }


### PR DESCRIPTION
受け入れテストを実装しました。
テスト内容は以下のとおりです。

- 全テストケース
  - ログの総数を確認してアサーション
  - すべて INFO ログであることをアサーション
- 自動販売機プログラムを起動してすぐ終了した場合
  - 初期の投入金額が 0 であることのアサーション
  - 起動時と終了時のログのアサーション
- 自動販売機プログラムを起動してコインを 1 度入れて何かを買おうとした場合
  - コーラを買う場合、購入できて 0 円になることをアサーション
  - お茶は上と同様
  - レッドブルの場合、購入できずに 100 円のままであることをアサーション
- 自動販売機プログラムを起動してコインを 2 度入れて何かを買おうとした場合
  - コーラを買う場合、購入できて 100 円になることをアサーション
  - レッドブルを買う場合、購入できて 0 円になることをアサーション
